### PR TITLE
(draft) Fix CMake files for MinGW

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,10 +91,13 @@ endif()
 if(MINGW)
     set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS} -static-libgcc")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++")
-    # Link 32 bit SolveSpace with --large-address-aware which allows it to access
-    # up to 3GB on a properly configured 32 bit Windows and up to 4GB on 64 bit.
-    # See https://msdn.microsoft.com/en-us/library/aa366778
-    set(CMAKE_EXE_LINKER_FLAGS "-Wl,--large-address-aware")
+    if(CMAKE_SYSTEM_PROCESSOR STREQUAL "i686")
+        # Link 32 bit SolveSpace with --large-address-aware which allows it to access
+        # up to 3GB on a properly configured 32 bit Windows and up to 4GB on 64 bit.
+        # See https://msdn.microsoft.com/en-us/library/aa366778
+        # This option is unavailable for 64-bit executable linking.
+        set(CMAKE_EXE_LINKER_FLAGS "-Wl,--large-address-aware")
+    endif()
 endif()
 
 # Ensure that all platforms use 64-bit IEEE floating point operations for consistency;

--- a/cmake/Toolchain-mingw32.cmake
+++ b/cmake/Toolchain-mingw32.cmake
@@ -1,4 +1,5 @@
 set(CMAKE_SYSTEM_NAME Windows)
+set(CMAKE_SYSTEM_PROCESSOR i686)
 
 set(TRIPLE i686-w64-mingw32)
 


### PR DESCRIPTION
Fixing CMake files to build Windows executables with **MinGW**.

## Error in compiling 32-bit Windows executable

```
[ 90%] Building CXX object extlib/angle/CMakeFiles/ANGLE.dir/src/libANGLE/renderer/d3d/RendererD3D.cpp.ob     [264/9194]
[ 91%] Building CXX object extlib/angle/CMakeFiles/ANGLE.dir/src/libANGLE/renderer/d3d/RenderTargetD3D.cpp.obj          In file included from /usr/lib/gcc/i686-w64-mingw32/10-win32/include/xmmintrin.h:1316,                                                   from /usr/lib/gcc/i686-w64-mingw32/10-win32/include/immintrin.h:29,                                                     from /usr/lib/gcc/i686-w64-mingw32/10-win32/include/x86intrin.h:32,                                                     from /usr/share/mingw-w64/include/intrin.h:73,                                                                          from /home/user/src/solvespace-solvespace/extlib/angle/src/common/platform.h:48,                                    from /home/user/src/solvespace-solvespace/extlib/angle/src/common/angleutils.h:12,                                  from /home/user/src/solvespace-solvespace/extlib/angle/src/common/debug.h:16,                                       from /home/user/src/solvespace-solvespace/extlib/angle/src/libANGLE/RefCountObject.h:15,
                 from /home/user/src/solvespace-solvespace/extlib/angle/src/libANGLE/angletypes.h:13,
                 from /home/user/src/solvespace-solvespace/extlib/angle/src/libANGLE/renderer/d3d/loadimage.h:12,
                 from /home/user/src/solvespace-solvespace/extlib/angle/src/libANGLE/renderer/d3d/loadimageSSE2.cpp:11:
/usr/lib/gcc/i686-w64-mingw32/10-win32/include/emmintrin.h: In function ‘void rx::LoadA8ToBGRA8_SSE2(size_t, size_t, siz                                                                       ‘
e_t, const uint8_t*, size_t, size_t, uint8_t*, size_t, size_t)’:
/usr/lib/gcc/i686-w64-mingw32/10-win32/include/emmintrin.h:770’: error: inlining failed in call to ‘always_inline’ ‘__m                                                                                                 ‘             ’ ‘128i _mm_setzero_si128()’: target specific option mismatch
  770 | _mm_setzero_si128 (void)
      | ^~~~~~~~~~~~~~~~~
/home/user/src/solvespace-solvespace/extlib/angle/src/libANGLE/renderer/d3d/loadimageSSE2.cpp:27:41: note: called from here
   27 |     __m128i zeroWide = _mm_setzero_si128();
      |                        ~~~~~~~~~~~~~~~~~^~
```

libANGLE requires SSE2 for compiling but it it not enable in `gcc`'s default configuration. And CMakeLists.txt doesn't work as intended because `CMAKE_SYSTEM_PROCESSOR` is not defined in MinGW 32-bit configuration. As a result, `-mfpmath=sse -msse2` was not added to the C flags.
So define `CMAKE_SYSTEM_PROCESSOR` in cmake/Toolchain_mingw32.cmake .

## Error in linking 64-bit Windows executable

```
[ 90%] Linking CXX executable ../bin/solvespace.exe
/usr/bin/x86_64-w64-mingw32-ld: unrecognized option '--large-address-aware'
/usr/bin/x86_64-w64-mingw32-ld: use the --help option for usage information
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/solvespace.dir/build.make:190: bin/solvespace.exe] Error 1
make[1]: *** [CMakeFiles/Makefile2:1139: src/CMakeFiles/solvespace.dir/all] Error 2
make: *** [Makefile:156: all] Error 2
```

The `ld` when linking 64-bit executable doesn't accept `--large-address-aware` option introduced in d6e1b23006580fb6bfb8d562264030524993bf1b .
So apply it only when linking 32-bit by checking `CMAKE_SYSTEM_PROCESSOR` described in the above section.

NOTE: No need to edit Visual Studio option because `/LARGEADDRESSAWARE` always accepted without any errors (but no effect; enabled on default for 64-bit linking).
